### PR TITLE
Fixed bug in mkl support (mkl_rt)

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -58,7 +58,7 @@ class PyNumpy(Package):
                     f.write('[mkl]\n')
                     f.write('library_dirs=%s\n' % spec['blas'].prefix.lib)
                     f.write('include_dirs=%s\n' % spec['blas'].prefix.include)
-                    f.write('mkl_libs=mkl_intel_lp64,mkl_sequential,mkl_core')
+                    f.write('mkl_libs=mkl_rt')
             else:
                 raise RuntimeError('py-numpy blas/lapack must be one of: openblas+lapack or mkl')
 


### PR DESCRIPTION
If we don't use mkl_rt, some functions are not found by numpy.

The standard way of building numpy/scipy with mkl is to use mkl_rt (https://software.intel.com/en-us/articles/numpyscipy-with-intel-mkl).